### PR TITLE
Canal Excavator Compatibility

### DIFF
--- a/cubium/compatibility/canal-excavator.lua
+++ b/cubium/compatibility/canal-excavator.lua
@@ -1,0 +1,15 @@
+if not mods["canal-excavator"] then return end
+
+data:extend({{
+  type = "mod-data",
+  name = "canex-cubium-config",
+  data_type = "canex-surface-config",
+  data = {
+    surfaceName = "cubium",
+    localisation = {"space-location-name.cubium"},
+    oreStartingAmount = 40,
+    mining_time = 2,
+    tint = {r = 43, g = 77, b = 128},
+    mineResult = "stone"
+  }
+}})

--- a/cubium/data.lua
+++ b/cubium/data.lua
@@ -28,3 +28,4 @@ if (mods["any-planet-start"]) then
     APS.add_planet{name = "cubium", filename = "__cubium__/cubium.lua", technology = "planet-discovery-cubium"}
     APS.add_planet{name = "aquilo", filename = "__cubium__/aquilo.lua", technology = "planet-discovery-aquilo"}
 end
+require("__cubium__.compatibility.canal-excavator")

--- a/cubium/info.json
+++ b/cubium/info.json
@@ -7,7 +7,8 @@
     "dependencies": ["base >= 2.0",
         "space-age >= 2.0",
         "quality >= 2.0",
-        "? any-planet-start >= 1.1.13"
+        "? any-planet-start >= 1.1.13",
+        "? canal-excavator >= 1.12"
     ],
     "space_travel_required": true,
     "description": "N/A"


### PR DESCRIPTION
Hi,

Some users of my [Canal Excavator](https://mods.factorio.com/mod/canal-excavator) mod asked me to implement compatibility with more planet mods.
Personally I think it's cleaner if the compatibility code is in the planet mod so let me know if you're okay with adding this.

I configured the excavatable resource on Cubium to yield stone since that seems to be abundant on your planet. If you have a better idea for what the soil of the planet should consist of, you can change the compat file as you'd like. It takes the name of an item or an array of [`ItemProductPrototype`](https://lua-api.factorio.com/2.0.72/types/ItemProductPrototype.html). 

In any case, you can tweak the parameters as you see fit, it's your planet after all!

Let me know what you think.